### PR TITLE
Dot-directory in blog post path no longer excluded

### DIFF
--- a/skinny.el
+++ b/skinny.el
@@ -48,7 +48,7 @@
   :group 'skinny
   :type 'integer)
 
-(defcustom skinny-host "localhost"
+(defcustom skinny-host "*"
   "The interface to start talking hipster shite on."
   :group 'skinny
   :type 'string)

--- a/skinny.el
+++ b/skinny.el
@@ -121,7 +121,7 @@ Published files are those not in the `drafts' folder."
   (let* ((excludes (list ".*/\\.*#.*"
                          ".*~"
                          ".*/drafts\\(/.*\\)*"
-                         ".*/\\."))
+                         ".*/\\.\\{1,2\\}\\'"))
          (files (loop for entry in
                      (apply 'skinny/directory-files
                             (concat skinny-root "/blog") excludes)


### PR DESCRIPTION
The fourth exclusion pattern tried in skinny/list-published incorrectly excludes any file or directory under a dot-directory. So for example everything under ~/.emacs.d/skinny/blog gets excluded, because of the leading "." in ".emacs.d". (Whether that's a good idea for where to place the skinny docroot is an orthogonal question, I think).

My fix WFM given the inputs I've encountered so far in my (trivial, one-post) setup. I don't really understand what's going on with the trailing "." and ".." filepath suffixes I see coming up in the debugger, which I've guessed are what the fourth pattern is meant to catch, but this fixes the problem for me ATM. I may have misunderstood the intended semantics of the fourth pattern, but there can be no doubting its current implementation is a defect causing the effect I describe. I'm sure you'll want to fix it, using either this fix or something better-informed based on your familiarity with the code.