### PR TITLE
skinny-sort-posts-by-filename

### DIFF
--- a/README.creole
+++ b/README.creole
@@ -63,26 +63,26 @@ Skinny Root: ~/myblog
     State : SAVED and set.
    The directory used tostore the skinny docroot.
 
-Hide Skinny Sort Posts By Filename: Toggle  on (non-nil)
+Skinny Sort Posts By Filename: Toggle  on (non-nil)
     State : SAVED and set.
    Sort blog posts by filename instead of by mtime. Hide
    If you enable this option, only files that match the following
    pattern are listed:
-   
+
      <YEAR>_<MONTH>/<DAY>-<post-title>.creole
-   
+
    where `<YEAR>_MONTH>/' is the directory containing the post.
    Then, if you have the following files:
-   
+
      2015_01/22-stuff.creole
      2015_02/05-more-stuff.creole
      2015_02/07-newest.creole
      random-post.creole
-   
+
    skinny/list-published will return:
-   
+
      (07-newest.creole 05-more-stuff.creole 22-stuff.creole random-post.creole)
-   
+
    Regardless of mtimes of the files.
 }}}
 

--- a/README.creole
+++ b/README.creole
@@ -62,6 +62,28 @@ Skinny Port: 8090
 Skinny Root: ~/myblog
     State : SAVED and set.
    The directory used tostore the skinny docroot.
+
+Hide Skinny Sort Posts By Filename: Toggle  on (non-nil)
+    State : SAVED and set.
+   Sort blog posts by filename instead of by mtime. Hide
+   If you enable this option, only files that match the following
+   pattern are listed:
+   
+     <YEAR>_<MONTH>/<DAY>-<post-title>.creole
+   
+   where `<YEAR>_MONTH>/' is the directory containing the post.
+   Then, if you have the following files:
+   
+     2015_01/22-stuff.creole
+     2015_02/05-more-stuff.creole
+     2015_02/07-newest.creole
+     random-post.creole
+   
+   skinny/list-published will return:
+   
+     (07-newest.creole 05-more-stuff.creole 22-stuff.creole random-post.creole)
+   
+   Regardless of mtimes of the files.
 }}}
 
 Set {{{skinny-root}}} to the root directory of your blog and


### PR DESCRIPTION
This branch adds skinny-sort-posts-by-filename, because I didn't want to deal with mtimes messing up my feed.
